### PR TITLE
changes to conditionally load header first

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,10 +6,10 @@
     <InternetExplorerPage v-if="isInternetExplorer" />
     <WorkInProgressWarning v-if="checkTypeOfEnv !== '' & !isInternetExplorer" /> <!-- an empty string in this case means the 'prod' version of the application   -->
     <router-view
-      v-if="!isInternetExplorer"
+      v-if="!isInternetExplorer & checkIfUSGSHeaderIsRendered"
     />
-    <PreFooterVisualizationsLinks v-if="checkIfIntroSectionIsRendered || !isInternetExplorer" />
-    <PreFooterCodeLinks v-if="checkIfIntroSectionIsRendered || !isInternetExplorer" />
+    <PreFooterVisualizationsLinks v-if="!isInternetExplorer" />
+    <PreFooterCodeLinks v-if="!isInternetExplorer" />
     <FooterUSGS />
   </div>
 </template>
@@ -37,9 +37,12 @@
             }
         },
         computed: {
-            checkTypeOfEnv() {
-                return process.env.VUE_APP_TIER
-            }
+          checkIfUSGSHeaderIsRendered() {
+            return this.$store.state.usgsHeaderRendered;
+          },
+          checkTypeOfEnv() {
+              return process.env.VUE_APP_TIER
+          }
         },
         created() {
             // We are ending support for Internet Explorer, so let's test to see if the browser used is IE.

--- a/src/components/HeaderUSGS.vue
+++ b/src/components/HeaderUSGS.vue
@@ -1,20 +1,20 @@
 <template>
   <section id="usgs-header">
     <header
-        id="navbar"
-        class="header-nav"
-        role="banner"
+      id="navbar"
+      class="header-nav"
+      role="banner"
     >
       <div class="tmp-container">
         <a
-            class="logo-header"
-            href="https://www.usgs.gov/"
-            title="Home"
+          class="logo-header"
+          href="https://www.usgs.gov/"
+          title="Home"
         >
           <img
-              class="img"
-              src="@/assets/usgsHeaderAndFooter/images/logo.png"
-              alt="Home"
+            class="img"
+            src="@/assets/usgsHeaderAndFooter/images/logo.png"
+            alt="Home"
           >
         </a>
       </div>

--- a/src/components/HeaderUSGS.vue
+++ b/src/components/HeaderUSGS.vue
@@ -1,67 +1,74 @@
 <template>
-  <div id="header">
+  <section id="usgs-header">
     <header
-      id="navbar"
-      class="header-nav"
-      role="banner"
+        id="navbar"
+        class="header-nav"
+        role="banner"
     >
       <div class="tmp-container">
         <a
-          class="logo-header"
-          href="https://www.usgs.gov/"
-          title="Home"
+            class="logo-header"
+            href="https://www.usgs.gov/"
+            title="Home"
         >
           <img
-            class="img"
-            src="@/assets/usgsHeaderAndFooter/images/logo.png"
-            alt="Home"
+              class="img"
+              src="@/assets/usgsHeaderAndFooter/images/logo.png"
+              alt="Home"
           >
         </a>
       </div>
     </header>
-  </div>
+  </section>
 </template>
 
 <script>
-    export default {
-        name: 'HeaderUSGS'
-    }
+export default {
+  name: 'HeaderUSGS',
+  mounted() {
+    // The following code will only run after the entire 'intro' section has been rendered
+    // it will change the Vuex state so that other components will know the 'intro' section has loaded
+    this.$nextTick(function () {
+      this.$store.commit('changeBooleanStateWhenUSGSHeaderRendered');
+    });
+  }
+}
 </script>
 
 <style scoped lang="scss">
-  header {
-    display: block;
+header {
+  display: block;
+}
+.tmp-container {
+  margin-right: auto;
+  margin-left: auto;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.tmp-container a {
+  text-decoration: none;
+  background: transparent;
+}
+.tmp-container:after {
+  clear: both;
+}
+@media only screen and (max-width:490px) {
+  hr {
+    margin-top: 60px;
   }
-  .tmp-container {
-    margin-right: auto;
-    margin-left: auto;
-    padding-left: 15px;
-    padding-right: 15px;
-  }
-  .tmp-container a {
-    text-decoration: none;
-    background: transparent;
-  }
-  .tmp-container:after {
-    clear: both;
-  }
-  @media only screen and (max-width:490px) {
-    hr {
-      margin-top: 60px;
-    }
-  }
-  /* header (only) nav */
-  .header-nav {
-    background: #00264c;
-  }
-  .logo-header img {
-    margin-top: 8px;
-    margin-bottom: 8px;
-    border: 0;
-    max-width: 100%;
-    height: auto;
-  }
-  .logo-header img {
-    height: 65px;
-  }
+}
+/* header (only) nav */
+.header-nav {
+  background: #00264c;
+}
+.logo-header img {
+  margin-top: 8px;
+  margin-bottom: 8px;
+  border: 0;
+  max-width: 100%;
+  height: auto;
+}
+.logo-header img {
+  height: 65px;
+}
 </style>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -5,10 +5,14 @@ Vue.use(Vuex);
 
 export const store = new Vuex.Store({
     state: {
+        usgsHeaderRendered: false,
         windowWidth: 0,
         windowHeight: 0,
     },
     mutations: {
+        changeBooleanStateWhenUSGSHeaderRendered(state) {
+            state.usgsHeaderRendered = true;
+        },
         recordWindowWidth (state, payload) {
             state.windowWidth = payload
         },


### PR DESCRIPTION
Before making a pull request
----------------------------
First . . .
- [x] Clean the code the way Vue likes it - run 'npm run lint --fix'        
- [x] Make sure all tests run

Then check for accessibly compliance
- [ ] Run WAVE plugin 508 compliance tool

Then run Browserstack; check that application works on . . .
- [x] Chrome
- [x] Safari
- [x] Edge
- [x] Firefox
- [x] Samsung Internet
- [x] Internet Explorer 11 (not supported, but still needs at least a working user redirect page)

Finally . . .
- [ ] Update the changelog appropriately

Standardize Template with New Loading Pattern
-----------
This forces the header to load first so that the remaining components will stack below it and not 'jump' about as they load.

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the ticket
- [ ] Assign someone to review unless the change is trivial
